### PR TITLE
fix: delete unnecessary function in parse rosbag

### DIFF
--- a/ros_ws/scripts/parse_rosbag.py
+++ b/ros_ws/scripts/parse_rosbag.py
@@ -8,7 +8,6 @@ import numpy as np
 from diffusion_planner_ros.lanelet2_utils.lanelet_converter import (
     convert_lanelet,
     create_lane_tensor,
-    fix_point_num,
 )
 from diffusion_planner_ros.utils import (
     create_current_ego_state,
@@ -101,7 +100,6 @@ if __name__ == "__main__":
     limit = args.limit
 
     vector_map = convert_lanelet(str(vector_map_path))
-    vector_map = fix_point_num(vector_map)
 
     serialization_format = "cdr"
     storage_options = rosbag2_py.StorageOptions(


### PR DESCRIPTION
## Description
`fix_point_num` was modified in 18b038ffcb9f182bf0b2b919270eba6b55f6a8d0, however the changes was not applied to `parse_rosbag.py`.

## How it was tested
Checked it worked with running the script.
```
python3 ./scripts/parse_rosbag.py /media/gosakayori/PortableSSD/manual_driving_data/2025-03-25/15-26-45/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0.db3 ~/autoware_map/shinagawa_odaiba/lanelet2_map.osm ~/tmp 
/usr/lib/python3/dist-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.17.3 and <1.25.0 is required for this version of SciPy (detected version 1.26.4
  warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
[INFO] [1744786737.265238741] [rosbag2_storage]: Opened database '/media/gosakayori/PortableSSD/manual_driving_data/2025-03-25/15-26-45/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0.db3' for READ_ONLY.
/perception/object_recognition/tracking/objects: 607 msgs
/planning/mission_planning/route: 1 msgs
/sensing/camera/camera0/image_rect_color/compressed: 586 msgs
/perception/traffic_light_recognition/traffic_signals: 507 msgs
/localization/acceleration: 2548 msgs
/localization/kinematic_state: 2469 msgs
n=607
 60%|████████████████████████                | 366/607 [00:00<00:00, 816.98it/s]i=21
Saved /home/gosakayori/tmp/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0_0000000000000021.npz
i=101
Saved /home/gosakayori/tmp/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0_0000000000000101.npz
i=181
Saved /home/gosakayori/tmp/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0_0000000000000181.npz
i=261
Saved /home/gosakayori/tmp/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0_0000000000000261.npz
i=341
Saved /home/gosakayori/tmp/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0_0000000000000341.npz
i=421
Saved /home/gosakayori/tmp/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0_0000000000000421.npz
i=501
Saved /home/gosakayori/tmp/532d0885-359b-4274-85bb-39bdb4373457_2025-03-25-15-26-45_p0900_0_0000000000000501.npz
100%|████████████████████████████████████████| 607/607 [00:01<00:00, 553.27it/s]

```