### PR TITLE
feat: onnx runtime implementation

### DIFF
--- a/ros_ws/scripts/run.sh
+++ b/ros_ws/scripts/run.sh
@@ -4,12 +4,12 @@ cd $(dirname $0)/../
 source /opt/ros/humble/setup.bash
 source ./install/setup.bash
 ros2 run diffusion_planner_ros diffusion_planner_node --ros-args \
-    -p vector_map_path:=/home/danielsanchez/diffusion_planner_data/lanelet2_map.osm \
-    -p config_json_path:=/home/danielsanchez/diffusion_planner_data/args.json \
-    -p ckpt_path:=/home/danielsanchez/diffusion_planner_data/latest.pth \
+    -p vector_map_path:=/home/shintarosakoda/data/driving_data/map/lanelet2_map.osm \
+    -p config_json_path:=/media/shintarosakoda/5EA85517A854EF51/diffusion_planner_training_result/train_result/2025-03-20-180651_datasize_1M/args.json \
+    -p ckpt_path:=/media/shintarosakoda/5EA85517A854EF51/diffusion_planner_training_result/train_result/2025-03-20-180651_datasize_1M/latest.pth \
     -p use_sim_time:=true \
     -p batch_size:=1 \
-    -p backend:=PYTHORCH \
+        -p backend:=PYTHORCH \
     -p onnx_path:=/home/danielsanchez/Diffusion-Planner/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/model.onnx
 
 

--- a/ros_ws/scripts/run.sh
+++ b/ros_ws/scripts/run.sh
@@ -4,8 +4,12 @@ cd $(dirname $0)/../
 source /opt/ros/humble/setup.bash
 source ./install/setup.bash
 ros2 run diffusion_planner_ros diffusion_planner_node --ros-args \
-    -p vector_map_path:=/home/shintarosakoda/data/driving_data/map/lanelet2_map.osm \
-    -p config_json_path:=/media/shintarosakoda/5EA85517A854EF51/diffusion_planner_training_result/train_result/2025-03-20-180651_datasize_1M/args.json \
-    -p ckpt_path:=/media/shintarosakoda/5EA85517A854EF51/diffusion_planner_training_result/train_result/2025-03-20-180651_datasize_1M/latest.pth \
+    -p vector_map_path:=/home/danielsanchez/diffusion_planner_data/lanelet2_map.osm \
+    -p config_json_path:=/home/danielsanchez/diffusion_planner_data/args.json \
+    -p ckpt_path:=/home/danielsanchez/diffusion_planner_data/latest.pth \
     -p use_sim_time:=true \
-    -p batch_size:=1
+    -p batch_size:=1 \
+    -p backend:=PYTHORCH \
+    -p onnx_path:=/home/danielsanchez/Diffusion-Planner/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/model.onnx
+
+

--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
@@ -49,6 +49,8 @@ torch.manual_seed(seed)
 
 # Load config
 config_json_path = "args.json"
+ckpt_path = "latest.pth"
+
 with open(config_json_path, "r") as f:
     config_json = json.load(f)
 config_obj = Config(config_json_path)
@@ -60,7 +62,6 @@ model.encoder.encoder.eval()
 model.decoder.decoder.eval()
 model.decoder.decoder.training = False
 
-ckpt_path = "latest.pth"
 ckpt = fileio.get(ckpt_path)
 with io.BytesIO(ckpt) as f:
     ckpt = torch.load(f)

--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
@@ -120,22 +120,22 @@ with torch.no_grad():
         print(f"Output {key} shape:", output[key].shape)
         torch_out = output[key].cpu().numpy()
 
-# onnx_model = torch.onnx.export(
-#     wrapper,
-#     input_tuple,
-#     "model.onnx",
-#     input_names=input_names,
-#     output_names=["output"],
-#     # dynamic_axes=None,
-#     dynamic_axes={name: {0: 'batch'}
-#                   for name in input_names},  # optional, but useful
-#     opset_version=20,
-# )
+onnx_model = torch.onnx.export(
+    wrapper,
+    input_tuple,
+    "model.onnx",
+    input_names=input_names,
+    output_names=["output"],
+    # dynamic_axes=None,
+    dynamic_axes={name: {0: 'batch'}
+                  for name in input_names},  # optional, but useful
+    opset_version=20,
+)
 
-sess_options = ort.SessionOptions()
-sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
+# sess_options = ort.SessionOptions()
+# sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
 ort_session = ort.InferenceSession(
-    "model.onnx", sess_options, providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+    "model.onnx",  providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
 
 inputs = {
     'ego_current_state': onnx_inputs['ego_current_state'].cpu().numpy(),
@@ -164,9 +164,9 @@ for i in ort_session.get_inputs():
 
 onnx_output = ort_session.run(None, inputs)
 print(f"torch output, with shape {torch_out.shape}:")
-# print(torch_out)
+print(torch_out)
 print(f"onnx output, with shape {onnx_output[0].shape}:")
-# print(onnx_output[0])
+print(onnx_output[0])
 
 abs_diff = np.abs(torch_out - onnx_output[0])
 print(f"Max diff: {abs_diff.max()}")

--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
@@ -69,28 +69,28 @@ new_state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
 model.load_state_dict(new_state_dict)
 
 # # Dummy inputs
-dummy_inputs = {
-    'ego_current_state': torch.tensor(np.random.randn(10).astype(np.float32)).unsqueeze(0),
-    'neighbor_agents_past': torch.tensor(np.random.randn(32, 21, 11).astype(np.float32)).unsqueeze(0),
-    'static_objects': torch.tensor(np.random.randn(5, 10).astype(np.float32)).unsqueeze(0),
-    'lanes': torch.tensor(np.random.randn(70, 20, 12).astype(np.float32)).unsqueeze(0),
-    'lanes_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).unsqueeze(0),
-    'lanes_has_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.bool_)).unsqueeze(0),
-    'route_lanes': torch.tensor(np.random.randn(25, 20, 12).astype(np.float32)).unsqueeze(0),
-}
-
 # dummy_inputs = {
-#     'ego_current_state': torch.full((1, 10), 0.5, dtype=torch.float32),
-#     'neighbor_agents_past': torch.full((1, 32, 21, 11), 0.5, dtype=torch.float32),
-#     'static_objects': torch.full((1, 5, 10), 0.5, dtype=torch.float32),
-#     'lanes': torch.full((1, 70, 20, 12), 0.5, dtype=torch.float32),
-#     'lanes_speed_limit': torch.full((1, 70, 1), 0.5, dtype=torch.float32),
-#     'lanes_has_speed_limit': torch.full((1, 70, 1), True, dtype=torch.bool),
-#     'route_lanes': torch.full((1, 25, 20, 12), 0.5, dtype=torch.float32),
+#     'ego_current_state': torch.tensor(np.random.randn(10).astype(np.float32)).unsqueeze(0),
+#     'neighbor_agents_past': torch.tensor(np.random.randn(32, 21, 11).astype(np.float32)).unsqueeze(0),
+#     'static_objects': torch.tensor(np.random.randn(5, 10).astype(np.float32)).unsqueeze(0),
+#     'lanes': torch.tensor(np.random.randn(70, 20, 12).astype(np.float32)).unsqueeze(0),
+#     'lanes_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).unsqueeze(0),
+#     'lanes_has_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.bool_)).unsqueeze(0),
+#     'route_lanes': torch.tensor(np.random.randn(25, 20, 12).astype(np.float32)).unsqueeze(0),
 # }
 
+dummy_inputs = {
+    'ego_current_state': torch.full((1, 10), 0.5, dtype=torch.float32),
+    'neighbor_agents_past': torch.full((1, 32, 21, 11), 0.5, dtype=torch.float32),
+    'static_objects': torch.full((1, 5, 10), 0.5, dtype=torch.float32),
+    'lanes': torch.full((1, 70, 20, 12), 0.5, dtype=torch.float32),
+    'lanes_speed_limit': torch.full((1, 70, 1), 0.5, dtype=torch.float32),
+    'lanes_has_speed_limit': torch.full((1, 70, 1), True, dtype=torch.bool),
+    'route_lanes': torch.full((1, 25, 20, 12), 0.5, dtype=torch.float32),
+}
 
-dummy_inputs = config_obj.observation_normalizer(dummy_inputs)
+
+# dummy_inputs = config_obj.observation_normalizer(dummy_inputs)
 torch_inputs = copy.deepcopy(dummy_inputs)
 onnx_inputs = copy.deepcopy(dummy_inputs)
 
@@ -149,6 +149,14 @@ inputs = {
 inputs['lanes_has_speed_limit'] = inputs['lanes_has_speed_limit'].astype(
     np.bool_)
 
+
+print("input dict")
+for key in inputs.keys():
+    print(
+        f"key {key}, shape {inputs[key].shape}, type {inputs[key].dtype}")
+print("onnx reqs")
+for i in ort_session.get_inputs():
+    print(f"Name: {i.name}, Shape: {i.shape}, Type: {i.type}")
 
 print("ONNX model input names:")
 for i in ort_session.get_inputs():

--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
@@ -1,11 +1,14 @@
 import torch
 import torch.nn as nn
+import onnx
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.utils.config import Config
 import json
 from mmengine import fileio
 import io
 import numpy as np
+import onnxruntime as ort
+torch.backends.mha.set_fastpath_enabled(False)
 
 
 class ONNXWrapper(nn.Module):
@@ -37,7 +40,7 @@ class ONNXWrapper(nn.Module):
             'route_lanes_has_speed_limit': route_lanes_has_speed_limit,
         }
         encoder_outputs, decoder_outputs = self.model(inputs)
-        return decoder_outputs  # or both if needed
+        return decoder_outputs
 
 
 # Load config
@@ -58,34 +61,35 @@ with io.BytesIO(ckpt) as f:
 state_dict = ckpt["model"]
 new_state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
 model.load_state_dict(new_state_dict)
-
+# model = torch.compile(model)
 
 # # Dummy inputs
 dummy_inputs = {
-    'ego_current_state': torch.tensor(np.random.randn(10).astype(np.float32)).cuda(),
-    'neighbor_agents_past': torch.tensor(np.random.randn(32, 21, 11).astype(np.float32)).cuda(),
-    'static_objects': torch.tensor(np.random.randn(5, 10).astype(np.float32)).cuda(),
-    'lanes': torch.tensor(np.random.randn(70, 20, 12).astype(np.float32)).cuda(),
-    'lanes_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).cuda(),
-    'lanes_has_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).cuda(),
-    'route_lanes': torch.tensor(np.random.randn(25, 20, 12).astype(np.float32)).cuda(),
-    'route_lanes_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda(),
-    'route_lanes_has_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda(),
+    'ego_current_state': torch.tensor(np.random.randn(10).astype(np.float32)).cuda().unsqueeze(0),
+    'neighbor_agents_past': torch.tensor(np.random.randn(32, 21, 11).astype(np.float32)).cuda().unsqueeze(0),
+    'static_objects': torch.tensor(np.random.randn(5, 10).astype(np.float32)).cuda().unsqueeze(0),
+    'lanes': torch.tensor(np.random.randn(70, 20, 12).astype(np.float32)).cuda().unsqueeze(0),
+    'lanes_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).cuda().unsqueeze(0),
+    'lanes_has_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.bool_)).cuda().unsqueeze(0),
+    'route_lanes': torch.tensor(np.random.randn(25, 20, 12).astype(np.float32)).cuda().unsqueeze(0),
+    'route_lanes_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda().unsqueeze(0),
+    'route_lanes_has_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda().unsqueeze(0),
 }
 
 sample_input = np.load("sample_input.npz")
 
 # dev = model.parameters().__next__().device
 for key in sample_input:
-    print("key", key)
-    print(sample_input[key].shape)
-    if (key == "map_name" or key == "token" or key == "ego_agent_future" or key == "neighbor_agents_future"):
+    if key in ['map_name', 'token', 'ego_agent_future', 'neighbor_agents_future']:
         continue
-    if isinstance(sample_input[key], np.ndarray):
-        dummy_inputs[key] = torch.tensor(sample_input[key]).cuda()
-        dummy_inputs[key] = dummy_inputs[key].unsqueeze(0)
+    val = sample_input[key]
+    if isinstance(val, np.ndarray):
+        if val.dtype.kind in {'U', 'S'}:  # Unicode or string
+            continue
+        dummy_inputs[key] = torch.tensor(val).cuda().unsqueeze(
+            0) if val.ndim > 0 else torch.tensor([val]).cuda()
 
-        print("dummy_inputs[key]\n", dummy_inputs[key])
+
 dummy_inputs = config_obj.observation_normalizer(dummy_inputs)
 
 # neighbors = dummy_inputs['neighbor_agents_past']
@@ -99,35 +103,76 @@ input_names = [
 
 wrapper = ONNXWrapper(model).eval().cuda()
 
-model(dummy_inputs)
 # Export
-# torch.onnx.export(
-#     model,
-#     tuple(dummy_inputs),
-#     "diffusion_planner.onnx",
+input_tuple = (
+    dummy_inputs['ego_current_state'],
+    dummy_inputs['neighbor_agents_past'],
+    dummy_inputs['static_objects'],
+    dummy_inputs['lanes'],
+    dummy_inputs['lanes_speed_limit'],
+    dummy_inputs['lanes_has_speed_limit'],
+    dummy_inputs['route_lanes'],
+    dummy_inputs['route_lanes_speed_limit'],
+    dummy_inputs['route_lanes_has_speed_limit'],
+)
+with torch.no_grad():
+    output = wrapper(*input_tuple)
+    for key in output.keys():
+        print(f"Output {key} shape:", output[key].shape)
+        torch_out = output[key].cpu().numpy()
+
+# onnx_model = torch.onnx.export(
+#     wrapper,
+#     input_tuple,
+#     "model.onnx",
 #     input_names=input_names,
 #     output_names=["output"],
-#     dynamic_axes=None,
+#     # dynamic_axes=None,
+#     dynamic_axes={name: {0: 'batch'}
+#                   for name in input_names},  # optional, but useful
 #     opset_version=17,
+
 # )
 
-# ort_session = ort.InferenceSession(
-#     "model.onnx", providers=['CPUExecutionProvider'])
+
+ort_session = ort.InferenceSession(
+    "model.onnx", providers=['CPUExecutionProvider'])
+
+onnx_model = onnx.load("model.onnx")
+print("Inputs:")
+for input in onnx_model.graph.input:
+    print(input.name)
+print("\nOutputs:")
+for output in onnx_model.graph.output:
+    print(output.name)
 
 # # Create NumPy input matching the shape of your dummy_inputs
 # inputs = {
-#     "ego_current_state": np.random.randn(10).astype(np.float32),
-#     "ego_agent_future": np.random.randn(80, 3).astype(np.float32),
-#     "neighbor_agents_past": np.random.randn(32, 21, 11).astype(np.float32),
-#     "neighbor_agents_future": np.random.randn(32, 80, 3).astype(np.float32),
-#     "static_objects": np.random.randn(5, 10).astype(np.float32),
-#     "lanes": np.random.randn(70, 20, 12).astype(np.float32),
-#     "lanes_speed_limit": np.random.randn(70, 1).astype(np.float32),
-#     "lanes_has_speed_limit": np.random.randn(70, 1).astype(np.float32),
-#     "route_lanes": np.random.randn(25, 20, 12).astype(np.float32),
-#     "route_lanes_speed_limit": np.random.randn(25, 1).astype(np.float32),
-#     "route_lanes_has_speed_limit": np.random.randn(25, 1).astype(np.float32),
+#     'ego_current_state': np.random.randn(1, 10).astype(np.float32),
+#     'neighbor_agents_past': np.random.randn(1, 32, 21, 11).astype(np.float32),
+#     'static_objects': np.random.randn(1, 5, 10).astype(np.float32),
+#     'lanes': np.random.randn(1, 70, 20, 12).astype(np.float32),
+#     'lanes_speed_limit': np.random.randn(1, 70, 1).astype(np.float32),
+#     'lanes_has_speed_limit': np.random.randn(1, 70, 1).astype(np.bool_),
+#     'route_lanes': np.random.randn(1, 25, 20, 12).astype(np.float32),
 # }
 
-# outputs = ort_session.run(None, inputs)
-# print(outputs[0])  # Or whatever your output is
+inputs = {
+    'ego_current_state': dummy_inputs['ego_current_state'].cpu().numpy(),
+    'neighbor_agents_past': dummy_inputs['neighbor_agents_past'].cpu().numpy(),
+    'static_objects': dummy_inputs['static_objects'].cpu().numpy(),
+    'lanes': dummy_inputs['lanes'].cpu().numpy(),
+    'lanes_speed_limit': dummy_inputs['lanes_speed_limit'].cpu().numpy(),
+    'lanes_has_speed_limit': dummy_inputs['lanes_has_speed_limit'].cpu().numpy(),
+    'route_lanes': dummy_inputs['route_lanes'].cpu().numpy(),
+}
+
+print("ONNX model input names:")
+for i in ort_session.get_inputs():
+    print(i.name, i.shape)
+
+outputs = ort_session.run(None, inputs)
+print(f"torch output, with shape {torch_out.shape}:")
+print(torch_out)
+print(f"onnx output, with shape {outputs[0].shape}:")
+print(outputs)

--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
@@ -1,3 +1,4 @@
+import copy
 import torch
 import torch.nn as nn
 import onnx
@@ -25,8 +26,6 @@ class ONNXWrapper(nn.Module):
         lanes_speed_limit,
         lanes_has_speed_limit,
         route_lanes,
-        route_lanes_speed_limit,
-        route_lanes_has_speed_limit,
     ):
         inputs = {
             'ego_current_state': ego_current_state,
@@ -36,8 +35,6 @@ class ONNXWrapper(nn.Module):
             'lanes_speed_limit': lanes_speed_limit,
             'lanes_has_speed_limit': lanes_has_speed_limit,
             'route_lanes': route_lanes,
-            'route_lanes_speed_limit': route_lanes_speed_limit,
-            'route_lanes_has_speed_limit': route_lanes_has_speed_limit,
         }
         encoder_outputs, decoder_outputs = self.model(inputs)
         return decoder_outputs
@@ -51,7 +48,9 @@ config_obj = Config(config_json_path)
 
 # Init model
 model = Diffusion_Planner(config_obj)
-model.eval().cuda()
+model.eval()
+model.encoder.encoder.eval()
+model.decoder.decoder.eval()
 model.decoder.decoder.training = False
 
 ckpt_path = "latest.pth"
@@ -61,78 +60,60 @@ with io.BytesIO(ckpt) as f:
 state_dict = ckpt["model"]
 new_state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
 model.load_state_dict(new_state_dict)
-# model = torch.compile(model)
 
 # # Dummy inputs
 dummy_inputs = {
-    'ego_current_state': torch.tensor(np.random.randn(10).astype(np.float32)).cuda().unsqueeze(0),
-    'neighbor_agents_past': torch.tensor(np.random.randn(32, 21, 11).astype(np.float32)).cuda().unsqueeze(0),
-    'static_objects': torch.tensor(np.random.randn(5, 10).astype(np.float32)).cuda().unsqueeze(0),
-    'lanes': torch.tensor(np.random.randn(70, 20, 12).astype(np.float32)).cuda().unsqueeze(0),
-    'lanes_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).cuda().unsqueeze(0),
-    'lanes_has_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.bool_)).cuda().unsqueeze(0),
-    'route_lanes': torch.tensor(np.random.randn(25, 20, 12).astype(np.float32)).cuda().unsqueeze(0),
-    'route_lanes_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda().unsqueeze(0),
-    'route_lanes_has_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda().unsqueeze(0),
+    'ego_current_state': torch.tensor(np.random.randn(10).astype(np.float32)).unsqueeze(0),
+    'neighbor_agents_past': torch.tensor(np.random.randn(32, 21, 11).astype(np.float32)).unsqueeze(0),
+    'static_objects': torch.tensor(np.random.randn(5, 10).astype(np.float32)).unsqueeze(0),
+    'lanes': torch.tensor(np.random.randn(70, 20, 12).astype(np.float32)).unsqueeze(0),
+    'lanes_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).unsqueeze(0),
+    'lanes_has_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.bool_)).unsqueeze(0),
+    'route_lanes': torch.tensor(np.random.randn(25, 20, 12).astype(np.float32)).unsqueeze(0),
 }
-
-sample_input = np.load("sample_input.npz")
-
-# dev = model.parameters().__next__().device
-for key in sample_input:
-    if key in ['map_name', 'token', 'ego_agent_future', 'neighbor_agents_future']:
-        continue
-    val = sample_input[key]
-    if isinstance(val, np.ndarray):
-        if val.dtype.kind in {'U', 'S'}:  # Unicode or string
-            continue
-        dummy_inputs[key] = torch.tensor(val).cuda().unsqueeze(
-            0) if val.ndim > 0 else torch.tensor([val]).cuda()
 
 
 dummy_inputs = config_obj.observation_normalizer(dummy_inputs)
+torch_inputs = copy.deepcopy(dummy_inputs)
+onnx_inputs = copy.deepcopy(dummy_inputs)
 
-# neighbors = dummy_inputs['neighbor_agents_past']
-# print("DEBUG type of neighbors:", type(neighbors))
 
 input_names = [
     'ego_current_state', 'neighbor_agents_past',
     'static_objects', 'lanes', 'lanes_speed_limit', 'lanes_has_speed_limit',
-    'route_lanes', 'route_lanes_speed_limit', 'route_lanes_has_speed_limit'
+    'route_lanes'
 ]
 
-wrapper = ONNXWrapper(model).eval().cuda()
+wrapper = ONNXWrapper(model).eval()
 
 # Export
 input_tuple = (
-    dummy_inputs['ego_current_state'],
-    dummy_inputs['neighbor_agents_past'],
-    dummy_inputs['static_objects'],
-    dummy_inputs['lanes'],
-    dummy_inputs['lanes_speed_limit'],
-    dummy_inputs['lanes_has_speed_limit'],
-    dummy_inputs['route_lanes'],
-    dummy_inputs['route_lanes_speed_limit'],
-    dummy_inputs['route_lanes_has_speed_limit'],
+    torch_inputs['ego_current_state'],
+    torch_inputs['neighbor_agents_past'],
+    torch_inputs['static_objects'],
+    torch_inputs['lanes'],
+    torch_inputs['lanes_speed_limit'],
+    torch_inputs['lanes_has_speed_limit'],
+    torch_inputs['route_lanes'],
 )
+
 with torch.no_grad():
     output = wrapper(*input_tuple)
     for key in output.keys():
         print(f"Output {key} shape:", output[key].shape)
         torch_out = output[key].cpu().numpy()
 
-# onnx_model = torch.onnx.export(
-#     wrapper,
-#     input_tuple,
-#     "model.onnx",
-#     input_names=input_names,
-#     output_names=["output"],
-#     # dynamic_axes=None,
-#     dynamic_axes={name: {0: 'batch'}
-#                   for name in input_names},  # optional, but useful
-#     opset_version=17,
-
-# )
+onnx_model = torch.onnx.export(
+    wrapper,
+    input_tuple,
+    "model.onnx",
+    input_names=input_names,
+    output_names=["output"],
+    # dynamic_axes=None,
+    dynamic_axes={name: {0: 'batch'}
+                  for name in input_names},  # optional, but useful
+    opset_version=20,
+)
 
 
 ort_session = ort.InferenceSession(
@@ -146,33 +127,37 @@ print("\nOutputs:")
 for output in onnx_model.graph.output:
     print(output.name)
 
-# # Create NumPy input matching the shape of your dummy_inputs
-# inputs = {
-#     'ego_current_state': np.random.randn(1, 10).astype(np.float32),
-#     'neighbor_agents_past': np.random.randn(1, 32, 21, 11).astype(np.float32),
-#     'static_objects': np.random.randn(1, 5, 10).astype(np.float32),
-#     'lanes': np.random.randn(1, 70, 20, 12).astype(np.float32),
-#     'lanes_speed_limit': np.random.randn(1, 70, 1).astype(np.float32),
-#     'lanes_has_speed_limit': np.random.randn(1, 70, 1).astype(np.bool_),
-#     'route_lanes': np.random.randn(1, 25, 20, 12).astype(np.float32),
-# }
-
 inputs = {
-    'ego_current_state': dummy_inputs['ego_current_state'].cpu().numpy(),
-    'neighbor_agents_past': dummy_inputs['neighbor_agents_past'].cpu().numpy(),
-    'static_objects': dummy_inputs['static_objects'].cpu().numpy(),
-    'lanes': dummy_inputs['lanes'].cpu().numpy(),
-    'lanes_speed_limit': dummy_inputs['lanes_speed_limit'].cpu().numpy(),
-    'lanes_has_speed_limit': dummy_inputs['lanes_has_speed_limit'].cpu().numpy(),
-    'route_lanes': dummy_inputs['route_lanes'].cpu().numpy(),
+    'ego_current_state': onnx_inputs['ego_current_state'].cpu().numpy(),
+    'neighbor_agents_past': onnx_inputs['neighbor_agents_past'].cpu().numpy(),
+    'static_objects': onnx_inputs['static_objects'].cpu().numpy(),
+    'lanes': onnx_inputs['lanes'].cpu().numpy(),
+    'lanes_speed_limit': onnx_inputs['lanes_speed_limit'].cpu().numpy(),
+    'lanes_has_speed_limit': onnx_inputs['lanes_has_speed_limit'].cpu().numpy(),
+    'route_lanes': onnx_inputs['route_lanes'].cpu().numpy(),
 }
+inputs['lanes_has_speed_limit'] = inputs['lanes_has_speed_limit'].astype(
+    np.bool_)
+
 
 print("ONNX model input names:")
 for i in ort_session.get_inputs():
     print(i.name, i.shape)
 
-outputs = ort_session.run(None, inputs)
+onnx_output = ort_session.run(None, inputs)
 print(f"torch output, with shape {torch_out.shape}:")
-print(torch_out)
-print(f"onnx output, with shape {outputs[0].shape}:")
-print(outputs)
+# print(torch_out)
+print(f"onnx output, with shape {onnx_output[0].shape}:")
+# print(onnx_output[0])
+
+abs_diff = np.abs(torch_out - onnx_output[0])
+print(f"Max diff: {abs_diff.max()}")
+print(f"Mean diff: {abs_diff.mean()}")
+print(
+    f"Close? {np.allclose(torch_out, onnx_output[0], rtol=1e-03, atol=1e-05)}")
+
+
+for input in ort_session.get_inputs():
+    print(f"{input.name}: {input.type}, {input.shape}")
+
+print({k: v.dtype for k, v in dummy_inputs.items()})

--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
@@ -1,0 +1,133 @@
+import torch
+import torch.nn as nn
+from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
+import json
+from mmengine import fileio
+import io
+import numpy as np
+
+
+class ONNXWrapper(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self,
+        ego_current_state,
+        neighbor_agents_past,
+        static_objects,
+        lanes,
+        lanes_speed_limit,
+        lanes_has_speed_limit,
+        route_lanes,
+        route_lanes_speed_limit,
+        route_lanes_has_speed_limit,
+    ):
+        inputs = {
+            'ego_current_state': ego_current_state,
+            'neighbor_agents_past': neighbor_agents_past,
+            'static_objects': static_objects,
+            'lanes': lanes,
+            'lanes_speed_limit': lanes_speed_limit,
+            'lanes_has_speed_limit': lanes_has_speed_limit,
+            'route_lanes': route_lanes,
+            'route_lanes_speed_limit': route_lanes_speed_limit,
+            'route_lanes_has_speed_limit': route_lanes_has_speed_limit,
+        }
+        encoder_outputs, decoder_outputs = self.model(inputs)
+        return decoder_outputs  # or both if needed
+
+
+# Load config
+config_json_path = "args.json"
+with open(config_json_path, "r") as f:
+    config_json = json.load(f)
+config_obj = Config(config_json_path)
+
+# Init model
+model = Diffusion_Planner(config_obj)
+model.eval().cuda()
+model.decoder.decoder.training = False
+
+ckpt_path = "latest.pth"
+ckpt = fileio.get(ckpt_path)
+with io.BytesIO(ckpt) as f:
+    ckpt = torch.load(f)
+state_dict = ckpt["model"]
+new_state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
+model.load_state_dict(new_state_dict)
+
+
+# # Dummy inputs
+dummy_inputs = {
+    'ego_current_state': torch.tensor(np.random.randn(10).astype(np.float32)).cuda(),
+    'neighbor_agents_past': torch.tensor(np.random.randn(32, 21, 11).astype(np.float32)).cuda(),
+    'static_objects': torch.tensor(np.random.randn(5, 10).astype(np.float32)).cuda(),
+    'lanes': torch.tensor(np.random.randn(70, 20, 12).astype(np.float32)).cuda(),
+    'lanes_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).cuda(),
+    'lanes_has_speed_limit': torch.tensor(np.random.randn(70, 1).astype(np.float32)).cuda(),
+    'route_lanes': torch.tensor(np.random.randn(25, 20, 12).astype(np.float32)).cuda(),
+    'route_lanes_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda(),
+    'route_lanes_has_speed_limit': torch.tensor(np.random.randn(25, 1).astype(np.float32)).cuda(),
+}
+
+sample_input = np.load("sample_input.npz")
+
+# dev = model.parameters().__next__().device
+for key in sample_input:
+    print("key", key)
+    print(sample_input[key].shape)
+    if (key == "map_name" or key == "token" or key == "ego_agent_future" or key == "neighbor_agents_future"):
+        continue
+    if isinstance(sample_input[key], np.ndarray):
+        dummy_inputs[key] = torch.tensor(sample_input[key]).cuda()
+        dummy_inputs[key] = dummy_inputs[key].unsqueeze(0)
+
+        print("dummy_inputs[key]\n", dummy_inputs[key])
+dummy_inputs = config_obj.observation_normalizer(dummy_inputs)
+
+# neighbors = dummy_inputs['neighbor_agents_past']
+# print("DEBUG type of neighbors:", type(neighbors))
+
+input_names = [
+    'ego_current_state', 'neighbor_agents_past',
+    'static_objects', 'lanes', 'lanes_speed_limit', 'lanes_has_speed_limit',
+    'route_lanes', 'route_lanes_speed_limit', 'route_lanes_has_speed_limit'
+]
+
+wrapper = ONNXWrapper(model).eval().cuda()
+
+model(dummy_inputs)
+# Export
+# torch.onnx.export(
+#     model,
+#     tuple(dummy_inputs),
+#     "diffusion_planner.onnx",
+#     input_names=input_names,
+#     output_names=["output"],
+#     dynamic_axes=None,
+#     opset_version=17,
+# )
+
+# ort_session = ort.InferenceSession(
+#     "model.onnx", providers=['CPUExecutionProvider'])
+
+# # Create NumPy input matching the shape of your dummy_inputs
+# inputs = {
+#     "ego_current_state": np.random.randn(10).astype(np.float32),
+#     "ego_agent_future": np.random.randn(80, 3).astype(np.float32),
+#     "neighbor_agents_past": np.random.randn(32, 21, 11).astype(np.float32),
+#     "neighbor_agents_future": np.random.randn(32, 80, 3).astype(np.float32),
+#     "static_objects": np.random.randn(5, 10).astype(np.float32),
+#     "lanes": np.random.randn(70, 20, 12).astype(np.float32),
+#     "lanes_speed_limit": np.random.randn(70, 1).astype(np.float32),
+#     "lanes_has_speed_limit": np.random.randn(70, 1).astype(np.float32),
+#     "route_lanes": np.random.randn(25, 20, 12).astype(np.float32),
+#     "route_lanes_speed_limit": np.random.randn(25, 1).astype(np.float32),
+#     "route_lanes_has_speed_limit": np.random.randn(25, 1).astype(np.float32),
+# }
+
+# outputs = ort_session.run(None, inputs)
+# print(outputs[0])  # Or whatever your output is


### PR DESCRIPTION
Added a way to create onnx models and then use them on the DP node. 

Tested with this setup 

```
 NVIDIA-SMI 570.124.06             Driver Version: 570.124.06     CUDA Version: 12.8     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 3090        Off |   00000000:01:00.0  On |                  N/A |
| 44%   56C    P0            123W /  350W |    2731MiB /  24576MiB |     26%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
```
```
>>> import onnxruntime as ort
>>> ort.__version__
'1.20.1'
```

>  cat /usr/include/cudnn_version.h | grep CUDNN_MAJOR -A 2
> #define CUDNN_MAJOR 9
> #define CUDNN_MINOR 8
> #define CUDNN_PATCHLEVEL 0
> --
> #define CUDNN_VERSION (CUDNN_MAJOR * 10000 + CUDNN_MINOR * 100 + CUDNN_PATCHLEVEL)
> 

With this PR inference time is halved: 
with ONNXRUNTIME backend: 

> [INFO] [1744789320.501587489] [diffusion_planner_node]: **Time Inference: 15.2345 msec**
> [INFO] [1744789320.598316981] [diffusion_planner_node]: Time Ego      : 0.3009 msec
> [INFO] [1744789320.599350167] [diffusion_planner_node]: Time Neighbor : 0.7968 msec
> [INFO] [1744789320.611426902] [diffusion_planner_node]: Time Lane     : 11.8029 msec
> [INFO] [1744789320.614489743] [diffusion_planner_node]: Time Route    : 2.7919 msec
> [INFO] [1744789320.630599743] [diffusion_planner_node]: **Time Inference: 15.2669 msec**
> [INFO] [1744789320.726321159] [diffusion_planner_node]: Time Ego      : 0.3536 msec
> [INFO] [1744789320.728294180] [diffusion_planner_node]: Time Neighbor : 1.7307 msec
> [INFO] [1744789320.740605039] [diffusion_planner_node]: Time Lane     : 12.0525 msec
> [INFO] [1744789320.744534336] [diffusion_planner_node]: Time Route    : 3.6945 msec
> [INFO] [1744789320.759476612] [diffusion_planner_node]: **Time Inference: 14.1590 msec**

with pythorch: 

[INFO] [1744793093.675444518] [diffusion_planner_node]: **Time Inference: 34.4803 msec**
[INFO] [1744793093.753748561] [diffusion_planner_node]: Time Ego      : 0.3536 msec
[INFO] [1744793093.755559219] [diffusion_planner_node]: Time Neighbor : 1.5070 msec
[INFO] [1744793093.767061076] [diffusion_planner_node]: Time Lane     : 11.2336 msec
[INFO] [1744793093.770195107] [diffusion_planner_node]: Time Route    : 2.8930 msec
x.shape in AgentFusionEncoder: torch.Size([1, 32, 21, 11])
[INFO] [1744793093.805162296] [diffusion_planner_node]: **Time Inference: 33.2386 msec**

HOW TO USE:
1) Create a .onnx model using the /conversion/torch2onnx.py script (Note that you may need to modify the config_json_path = "args.json" and ckpt_path = "latest.pth", to point to your files.
2) in the run.sh file change the "backend" parameter to "ONNXRUNTIME" or "PYTHORCH" for the backend you want to use. Then, modify the onnx_path to point to the model.onnx file generated in step 1

