### PR TITLE
feat: add onnx-friendly ops to replace original ops

### DIFF
--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/onnx_compatible_transformer.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/onnx_compatible_transformer.py
@@ -1,0 +1,182 @@
+from torch.fx import symbolic_trace, GraphModule
+from torch.fx.graph import Node
+import torch.nn as nn
+import torch
+import copy
+
+from diffusion_planner.model.module.encoder import *
+
+
+class ONNXWrapper(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self,
+        ego_current_state,
+        neighbor_agents_past,
+        static_objects,
+        lanes,
+        lanes_speed_limit,
+        lanes_has_speed_limit,
+        route_lanes,
+    ):
+        inputs = {
+            "ego_current_state": ego_current_state,
+            "neighbor_agents_past": neighbor_agents_past,
+            "static_objects": static_objects,
+            "lanes": lanes,
+            "lanes_speed_limit": lanes_speed_limit,
+            "lanes_has_speed_limit": lanes_has_speed_limit,
+            "route_lanes": route_lanes,
+        }
+        encoder_outputs, decoder_outputs = self.model(inputs)
+        return decoder_outputs
+
+
+class LaneFusionEncoderONNX(nn.Module):
+    def __init__(self, original: LaneFusionEncoder):
+        super().__init__()
+
+        self._lane_len = original._lane_len
+        self._channel = original._channel
+
+        self.speed_limit_emb = original.speed_limit_emb
+        self.unknown_speed_emb = original.unknown_speed_emb
+        self.traffic_emb = original.traffic_emb
+
+        self.channel_pre_project = original.channel_pre_project
+        self.token_pre_project = original.token_pre_project
+
+        self.blocks = original.blocks
+
+        self.norm = original.norm
+        self.emb_project = original.emb_project
+
+    def forward(self, x, speed_limit, has_speed_limit):
+        '''
+        x: B, P, V, D (x, y, x'-x, y'-y, x_left-x, y_left-y, x_right-x, y_right-y, traffic(4))
+        speed_limit: B, P, 1
+        has_speed_limit: B, P, 1
+        '''
+        traffic = x[:, :, 0, 8:]
+        x = x[..., :8]
+
+        pos = x[:, :, int(self._lane_len / 2), :7].clone()
+        heading = torch.atan2(pos[..., 3], pos[..., 2])
+        pos[..., 2] = torch.cos(heading)
+        pos[..., 3] = torch.sin(heading)
+        pos[..., -3:] = 0.0
+        pos[..., -1] = 1.0
+
+        B, P, V, _ = x.shape
+        mask_v = torch.sum(torch.ne(x[..., :8], 0), dim=-1) == 0
+        mask_p = torch.sum(~mask_v, dim=-1) == 0
+        valid_indices = ~mask_p.view(-1)
+
+        x = x.view(B * P, V, -1)
+        x = torch.where(
+            valid_indices.view(-1, 1, 1),
+            x,
+            torch.zeros_like(x)
+        )
+
+        x = self.channel_pre_project(x)
+        x = x.permute(0, 2, 1)
+        x = self.token_pre_project(x)
+        x = x.permute(0, 2, 1)
+        for block in self.blocks:
+            x = block(x)
+
+        x = torch.mean(x, dim=1)
+
+        speed_limit = speed_limit.view(B * P, 1)
+        has_speed_limit = has_speed_limit.view(B * P, 1)
+        traffic = traffic.view(B * P, -1)
+
+        speed_limit_input = speed_limit
+        speed_limit_emb = self.speed_limit_emb(speed_limit_input)
+
+        unknown_speed_emb = self.unknown_speed_emb(
+            torch.zeros(B * P, dtype=torch.long, device=x.device))
+        speed_limit_embedding = has_speed_limit * speed_limit_emb + \
+            (~has_speed_limit) * unknown_speed_emb
+
+        traffic_light_embedding = self.traffic_emb(traffic)
+
+        x = x + speed_limit_embedding + traffic_light_embedding
+        x = self.emb_project(self.norm(x))
+
+        x_result = x * valid_indices.float().unsqueeze(-1)
+        return x_result.view(B, P, -1), mask_p.view(B, -1), pos.view(B, P, -1)
+
+
+class StaticFusionEncoderONNX(nn.Module):
+    def __init__(self, original: StaticFusionEncoder):
+        super().__init__()
+        self._hidden_dim = original._hidden_dim
+        self.projection = original.projection  # Reuse original weights
+
+    def forward(self, x):
+        B, P, _ = x.shape
+
+        # Create position tensor safely
+        pos = x[:, :, :7]
+        first_part = pos[..., :-3]
+        middle = torch.zeros_like(pos[..., -3:])
+        middle[..., -2] = 1.0
+        pos = torch.cat([first_part, middle], dim=-1)
+
+        x_result = torch.zeros((B * P, self._hidden_dim), device=x.device)
+
+        mask_p = torch.sum(torch.ne(x[..., :10], 0), dim=-1) == 0
+        valid_mask = ~mask_p.view(-1)
+
+        x_flat = x.view(B * P, -1)
+        x_proj_input = x_flat[valid_mask]
+
+        # Always do projection (ONNX can't branch)
+        safe_input = torch.cat([
+            x_proj_input,
+            torch.zeros((1, x_flat.shape[-1]), device=x.device)
+        ], dim=0)
+        safe_output = self.projection(safe_input)
+
+        # Take only the valid part (original number of valid rows)
+        proj_out = safe_output[:x_proj_input.shape[0]]
+
+        # Scatter result into x_result
+        x_result[valid_mask] = proj_out
+
+        return x_result.view(B, P, -1), mask_p.view(B, P), pos.view(B, P, -1)
+
+
+class ONNXSafeModel(nn.Module):
+    def __init__(self, original_model):
+        super().__init__()
+        self.model = copy.deepcopy(original_model)
+        self._replace_with_onnx_safe_modules()
+
+    def _replace_with_onnx_safe_modules(self):
+        for name, module in self.model.named_modules():
+            if isinstance(module, StaticFusionEncoder):
+                parent_module = self._get_parent_module(name)
+                subname = name.split(".")[-1]
+                setattr(parent_module, subname,
+                        StaticFusionEncoderONNX(module))
+            if isinstance(module, LaneFusionEncoder):
+                parent_module = self._get_parent_module(name)
+                subname = name.split(".")[-1]
+                setattr(parent_module, subname,
+                        LaneFusionEncoderONNX(module))
+
+    def _get_parent_module(self, name):
+        parts = name.split(".")[:-1]
+        mod = self.model
+        for part in parts:
+            mod = getattr(mod, part)
+        return mod
+
+    def forward(self, *args, **kwargs):
+        return self.model(*args, **kwargs)

--- a/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
+++ b/ros_ws/src/diffusion_planner_ros/diffusion_planner_ros/conversion/torch2onnx.py
@@ -1,6 +1,7 @@
 import copy
 import torch
 import torch.nn as nn
+from onnx_compatible_transformer import *
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.utils.config import Config
 import json
@@ -16,6 +17,10 @@ torch.backends.mha.set_fastpath_enabled(False)
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Convert torch model to onnx")
     parser.add_argument(
+        "--test_only", action="store_true",
+        help="If set, only test the output of the existing ONNX model")
+
+    parser.add_argument(
         "--config", type=str, default="args.json", help="Config file path"
     )
     parser.add_argument(
@@ -25,7 +30,10 @@ def parse_args() -> argparse.Namespace:
         "--onnx_path", type=str, default="model.onnx", help="ONNX model file path"
     )
     parser.add_argument(
-        "--sample_input", type=str, default="sample_input.npz", help="Sample input path"
+        "--sample_input_path", type=str, default="sample_input.npz", help="Sample input path"
+    )
+    parser.add_argument(
+        "--wrap_with_onnx_functions", action="store_true", help="Wether to replace some original functions with onnx-friendly ones"
     )
     args = parser.parse_args()
     return args
@@ -59,34 +67,57 @@ class ONNXWrapper(nn.Module):
         return decoder_outputs
 
 
+def create_input(input_dict, input_type="onnx"):
+    if input_type == "onnx":
+        return {
+            "ego_current_state": input_dict["ego_current_state"].cpu().numpy(),
+            "neighbor_agents_past": input_dict["neighbor_agents_past"].cpu().numpy(),
+            "static_objects": input_dict["static_objects"].cpu().numpy(),
+            "lanes": input_dict["lanes"].cpu().numpy(),
+            "lanes_speed_limit": input_dict["lanes_speed_limit"].cpu().numpy(),
+            "lanes_has_speed_limit": input_dict["lanes_has_speed_limit"].cpu().numpy(),
+            "route_lanes": input_dict["route_lanes"].cpu().numpy(),
+        }
+    elif input_type == "torch":
+        return (
+            input_dict["ego_current_state"],
+            input_dict["neighbor_agents_past"],
+            input_dict["static_objects"],
+            input_dict["lanes"],
+            input_dict["lanes_speed_limit"],
+            input_dict["lanes_has_speed_limit"],
+            input_dict["route_lanes"],
+        )
+
+
+def compare_outputs(torch_output, onnx_output):
+    print(f"torch output, with shape {torch_output.shape}:")
+    print(f"onnx output, with shape {onnx_output[0].shape}:")
+    abs_diff = np.abs(torch_output - onnx_output[0])
+    print(f"Max diff: {abs_diff.max()}")
+    print(f"Mean diff: {abs_diff.mean()}")
+    print(
+        f"Close? {np.allclose(torch_output, onnx_output[0], rtol=1e-03, atol=1e-05)}")
+
+
 if __name__ == "__main__":
     args = parse_args()
     config_json_path = args.config
     ckpt_path = args.ckpt
     onnx_path = args.onnx_path
-    sample_input = args.sample_input
-
-    seed = 42
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
+    sample_input_path = args.sample_input_path
+    wrap_with_onnx = args.wrap_with_onnx_functions
+    test_only = args.test_only
 
     # Load config
     with open(config_json_path, "r") as f:
         config_json = json.load(f)
     config_obj = Config(config_json_path)
 
-    # Init model
-    model = Diffusion_Planner(config_obj)
-    model.eval()
-    model.encoder.encoder.eval()
-    model.decoder.decoder.eval()
-    model.decoder.decoder.training = False
-
-    ckpt = torch.load(ckpt_path)
-    state_dict = ckpt["model"]
-    new_state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
-    model.load_state_dict(new_state_dict)
+    seed = 42
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
 
     # # Dummy inputs
     # dummy_inputs = {
@@ -109,10 +140,6 @@ if __name__ == "__main__":
         "route_lanes": torch.full((1, 25, 20, 12), 0.5, dtype=torch.float32),
     }
 
-    # dummy_inputs = config_obj.observation_normalizer(dummy_inputs)
-    torch_inputs = copy.deepcopy(dummy_inputs)
-    onnx_inputs = copy.deepcopy(dummy_inputs)
-
     input_names = [
         "ego_current_state",
         "neighbor_agents_past",
@@ -123,136 +150,79 @@ if __name__ == "__main__":
         "route_lanes",
     ]
 
-    wrapper = ONNXWrapper(model).eval()
-
     # Export
-    input_tuple = (
-        torch_inputs["ego_current_state"],
-        torch_inputs["neighbor_agents_past"],
-        torch_inputs["static_objects"],
-        torch_inputs["lanes"],
-        torch_inputs["lanes_speed_limit"],
-        torch_inputs["lanes_has_speed_limit"],
-        torch_inputs["route_lanes"],
-    )
+    # Init model
+    model = Diffusion_Planner(config_obj)
+    model.eval()
+    model.encoder.encoder.eval()
+    model.decoder.decoder.eval()
+    model.decoder.decoder.training = False
+
+    ckpt = torch.load(ckpt_path)
+    state_dict = ckpt["model"]
+    new_state_dict = {k.replace("module.", ""): v for k,
+                      v in state_dict.items()}
+    model.load_state_dict(new_state_dict)
+
+    # Wrap model for onnx compatibility
+    if wrap_with_onnx:
+        onnx_safe_model = ONNXSafeModel(model).eval()
+        wrapper = ONNXWrapper(onnx_safe_model).eval()
+    else:
+        wrapper = ONNXWrapper(model).eval()
+
+    # Prepare input
+    torch_input_tuple = create_input(dummy_inputs, "torch")
+
+    if not test_only:
+        print(f"creating a new onnx model: {onnx_path}")
+        onnx_model = torch.onnx.export(
+            wrapper,
+            torch_input_tuple,
+            onnx_path,
+            input_names=input_names,
+            output_names=["output"],
+            # dynamic_axes=None,
+            dynamic_axes={
+                name: {0: "batch"} for name in input_names
+            },  # optional, but useful
+            opset_version=20,
+        )
 
     with torch.no_grad():
-        output = wrapper(*input_tuple)
-        for key in output.keys():
-            print(f"Output {key} shape:", output[key].shape)
-            torch_out = output[key].cpu().numpy()
+        output = wrapper(*torch_input_tuple)
+        torch_output = output["prediction"].cpu().numpy()
 
-    onnx_model = torch.onnx.export(
-        wrapper,
-        input_tuple,
-        onnx_path,
-        input_names=input_names,
-        output_names=["output"],
-        # dynamic_axes=None,
-        dynamic_axes={
-            name: {0: "batch"} for name in input_names
-        },  # optional, but useful
-        opset_version=20,
-    )
-
-    # sess_options = ort.SessionOptions()
+    sess_options = ort.SessionOptions()
     # sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
     ort_session = ort.InferenceSession(
-        onnx_path, providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+        onnx_path, sess_options, providers=[
+            "CUDAExecutionProvider", "CPUExecutionProvider"]
     )
 
-    inputs = {
-        "ego_current_state": onnx_inputs["ego_current_state"].cpu().numpy(),
-        "neighbor_agents_past": onnx_inputs["neighbor_agents_past"].cpu().numpy(),
-        "static_objects": onnx_inputs["static_objects"].cpu().numpy(),
-        "lanes": onnx_inputs["lanes"].cpu().numpy(),
-        "lanes_speed_limit": onnx_inputs["lanes_speed_limit"].cpu().numpy(),
-        "lanes_has_speed_limit": onnx_inputs["lanes_has_speed_limit"].cpu().numpy(),
-        "route_lanes": onnx_inputs["route_lanes"].cpu().numpy(),
-    }
-    inputs["lanes_has_speed_limit"] = inputs["lanes_has_speed_limit"].astype(np.bool_)
-
-    print("input dict")
-    for key in inputs.keys():
-        print(f"key {key}, shape {inputs[key].shape}, type {inputs[key].dtype}")
-    print("onnx reqs")
-    for i in ort_session.get_inputs():
-        print(f"Name: {i.name}, Shape: {i.shape}, Type: {i.type}")
-
-    print("ONNX model input names:")
-    for i in ort_session.get_inputs():
-        print(i.name, i.shape)
-
-    onnx_output = ort_session.run(None, inputs)
-    print(f"torch output, with shape {torch_out.shape}:")
-    print(torch_out)
-    print(f"onnx output, with shape {onnx_output[0].shape}:")
-    print(onnx_output[0])
-
-    abs_diff = np.abs(torch_out - onnx_output[0])
-    print(f"Max diff: {abs_diff.max()}")
-    print(f"Mean diff: {abs_diff.mean()}")
-    print(f"Close? {np.allclose(torch_out, onnx_output[0], rtol=1e-03, atol=1e-05)}")
+    onnx_inputs = create_input(dummy_inputs, "onnx")
+    onnx_output = ort_session.run(None, onnx_inputs)
+    print("Compare outputs using the creation input")
+    compare_outputs(torch_output, onnx_output)
 
     # TEST WITH SAMPLE INPUT
-    print("Comparison with sample input")
     # Load the sample input
-    sample_input_temp = np.load(sample_input)
+    sample_input_file = np.load(sample_input_path)
     sample_input = {}
-    for key in sample_input_temp:
-        if key in [
-            "map_name",
-            "token",
-            "ego_agent_future",
-            "neighbor_agents_future",
-            "route_speed_limit",
-            "route_has_speed_limit",
-        ]:
-            continue
-        val = sample_input_temp[key]
-        if isinstance(val, np.ndarray):
-            if val.dtype.kind in {"U", "S"}:  # Unicode or string
-                continue
-            sample_input[key] = (
-                torch.tensor(val).unsqueeze(0) if val.ndim > 0 else torch.tensor([val])
-            )
+    for key in input_names:
+        sample_input[key] = (
+            torch.tensor(sample_input_file[key]).unsqueeze(0)
+        )
 
     sample_input = config_obj.observation_normalizer(sample_input)
 
-    input_tuple = (
-        sample_input["ego_current_state"],
-        sample_input["neighbor_agents_past"],
-        sample_input["static_objects"],
-        sample_input["lanes"],
-        sample_input["lanes_speed_limit"],
-        sample_input["lanes_has_speed_limit"],
-        sample_input["route_lanes"],
-    )
-
+    # Run torch inference
+    torch_input_tuple = create_input(sample_input, "torch")
     with torch.no_grad():
-        output = wrapper(*input_tuple)
-        for key in output.keys():
-            # print(f"Output {key} shape:", output[key].shape)
-            torch_out = output[key].cpu().numpy()
+        output = wrapper(*torch_input_tuple)
+        torch_output = output["prediction"].cpu().numpy()
+    onnx_inputs = create_input(sample_input, "onnx")
+    onnx_output = ort_session.run(None, onnx_inputs)
 
-    inputs = {
-        "ego_current_state": sample_input["ego_current_state"].cpu().numpy(),
-        "neighbor_agents_past": sample_input["neighbor_agents_past"].cpu().numpy(),
-        "static_objects": sample_input["static_objects"].cpu().numpy(),
-        "lanes": sample_input["lanes"].cpu().numpy(),
-        "lanes_speed_limit": sample_input["lanes_speed_limit"].cpu().numpy(),
-        "lanes_has_speed_limit": sample_input["lanes_has_speed_limit"].cpu().numpy(),
-        "route_lanes": sample_input["route_lanes"].cpu().numpy(),
-    }
-    onnx_output = ort_session.run(None, inputs)
-    print(f"torch output, with shape {torch_out.shape}:")
-    # print(torch_out)
-    print(f"onnx output, with shape {onnx_output[0].shape}:")
-    # print(onnx_output[0])
-
-    abs_diff = np.abs(torch_out - onnx_output[0])
-    print(f"Max diff: {abs_diff.max()}")
-    print(f"Mean diff: {abs_diff.mean()}")
-    print(f"Close? {np.allclose(torch_out, onnx_output[0], rtol=1e-03, atol=1e-05)}")
-    for i in ort_session.get_inputs():
-        print(f"Name: {i.name}, Shape: {i.shape}, Type: {i.type}")
+    print("Compare outputs using a sample input")
+    compare_outputs(torch_output, onnx_output)


### PR DESCRIPTION
This PR adds onnx-friendly operations (no python boolean logic) to the onnx export. This PR lets us prevent some warnings and possibly evade issues when running the model. 